### PR TITLE
Remove x-ua-compatible metatag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>What tatoo next?</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/src/index.html
+++ b/src/index.html
@@ -4,24 +4,23 @@
 <head>
   <meta charset="utf-8">
   <title>What tatoo next?</title>
-  <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-  <link rel="manifest" href="site.webmanifest">
-  <link rel="apple-touch-icon" href="icon.png">
+  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" href="icon.png" />
   <!-- Place favicon.ico in the root directory -->
 
-  <link rel="stylesheet" href="css/main.css">
-  <link rel="stylesheet" href="css/my.css">
-
-  <link href="https://fonts.googleapis.com/css?family=Coda+Caption:800|Roboto+Mono" rel="stylesheet">
+  <!-- CSS -->
+  <link rel="stylesheet" href="css/main.css" />
+  <link rel="stylesheet" href="css/my.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Coda+Caption:800|Roboto+Mono" />
 </head>
 
 <body>
   <!--[if lte IE 9]>
-<p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade
-  your browser</a> to improve your experience and security.</p>
-<![endif]-->
+    <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
+  <![endif]-->
 
   <div id="content">
     <header>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title></title>
+  <title>What tatoo next?</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 


### PR DESCRIPTION
- Self close `<meta>` and `<link>`tags;
- Add content to page  `<title>`;
- Keep CSS links all together (minor);
- Remove `<meta http-equiv="X-UA-Compatible" content="ie=edge">`;

   From Microsoft [Specifying legacy document modes](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj676915%28v%3dvs.85%29) documentation page:

   > Use the following value to display the webpage in EdgeHTML mode, which is the highest standards mode supported by Internet Explorer, from Internet Explorer 6 through IE11.
   >
   > ```<meta http-equiv="x-ua-compatible" content="IE=edge" >```
   > 
   > **Note that this is functionally equivalent to using the HTML5 doctype.** It places Internet Explorer into the highest supported document mode. Edge most is most useful for regularly maintained websites that are routinely tested for interoperability between multiple browsers, including Internet Explorer.